### PR TITLE
Added gfx_set_combine_lerp to lua

### DIFF
--- a/autogen/lua_definitions/functions.lua
+++ b/autogen/lua_definitions/functions.lua
@@ -9239,6 +9239,27 @@ function gfx_parse(cmd, func)
 end
 
 --- @param gfx Pointer_Gfx
+--- @param a0 integer
+--- @param b0 integer
+--- @param c0 integer
+--- @param d0 integer
+--- @param Aa0 integer
+--- @param Ab0 integer
+--- @param Ac0 integer
+--- @param Ad0 integer
+--- @param a1 integer
+--- @param b1 integer
+--- @param c1 integer
+--- @param d1 integer
+--- @param Aa1 integer
+--- @param Ab1 integer
+--- @param Ac1 integer
+--- @param Ad1 integer
+function gfx_set_combine_lerp(gfx, a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0, a1, b1, c1, d1, Aa1, Ab1, Ac1, Ad1)
+    -- ...
+end
+
+--- @param gfx Pointer_Gfx
 --- @param type integer
 function gfx_set_cycle_type(gfx, type)
     -- ...

--- a/docs/lua/functions-5.md
+++ b/docs/lua/functions-5.md
@@ -7923,6 +7923,42 @@ Gets a value of the global vertex shading color
 
 <br />
 
+## [gfx_set_combine_lerp](#gfx_set_combine_lerp)
+
+### Lua Example
+`gfx_set_combine_lerp(gfx, a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0, a1, b1, c1, d1, Aa1, Ab1, Ac1, Ad1)`
+
+### Parameters
+| Field | Type |
+| ----- | ---- |
+| gfx | `Pointer` <`Gfx`> |
+| a0 | `integer` |
+| b0 | `integer` |
+| c0 | `integer` |
+| d0 | `integer` |
+| Aa0 | `integer` |
+| Ab0 | `integer` |
+| Ac0 | `integer` |
+| Ad0 | `integer` |
+| a1 | `integer` |
+| b1 | `integer` |
+| c1 | `integer` |
+| d1 | `integer` |
+| Aa1 | `integer` |
+| Ab1 | `integer` |
+| Ac1 | `integer` |
+| Ad1 | `integer` |
+
+### Returns
+- None
+
+### C Prototype
+`void gfx_set_combine_lerp(Gfx* gfx, u32 a0, u32 b0, u32 c0, u32 d0, u32 Aa0, u32 Ab0, u32 Ac0, u32 Ad0, u32 a1, u32 b1, u32 c1, u32 d1,	u32 Aa1, u32 Ab1, u32 Ac1, u32 Ad1);`
+
+[:arrow_up_small:](#)
+
+<br />
+
 ## [gfx_set_cycle_type](#gfx_set_cycle_type)
 
 ### Lua Example

--- a/docs/lua/functions.md
+++ b/docs/lua/functions.md
@@ -1709,6 +1709,7 @@
    - [gfx_copy_lights_player_part](functions-5.md#gfx_copy_lights_player_part)
    - [gfx_get_vtx](functions-5.md#gfx_get_vtx)
    - [gfx_parse](functions-5.md#gfx_parse)
+   - [gfx_set_combine_lerp](functions-5.md#gfx_set_combine_lerp)
    - [gfx_set_cycle_type](functions-5.md#gfx_set_cycle_type)
    - [gfx_set_env_color](functions-5.md#gfx_set_env_color)
    - [gfx_set_fog_color](functions-5.md#gfx_set_fog_color)

--- a/include/PR/gbi.h
+++ b/include/PR/gbi.h
@@ -3197,6 +3197,28 @@ typedef union {
 					       G_ACMUX_##Ad1));		\
 }
 
+#define	gDPSetCombineLERPNoString(pkt, a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0,	\
+	a1, b1, c1, d1,	Aa1, Ab1, Ac1, Ad1)			\
+{									\
+	Gfx *_g = (Gfx *)(pkt);						\
+								\
+	_g->words.w0 =	_SHIFTL(G_SETCOMBINE, 24, 8) |			\
+		_SHIFTL(GCCc0w0(a0, c0,	\
+				   Aa0, Ac0) |	\
+			   GCCc1w0(a1, c1), 	\
+			   0, 24);					\
+	_g->words.w1 =	(unsigned int)(GCCc0w1(b0, 		\
+					   d0,		\
+					   Ab0, 		\
+					   Ad0) |		\
+				   GCCc1w1(b1, 		\
+					   Aa1,		\
+					   Ac1, 		\
+					   d1,		\
+					   Ab1, 		\
+					   Ad1));		\
+}
+
 #define	gsDPSetCombineLERP(a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0,		\
 		a1, b1, c1, d1,	Aa1, Ab1, Ac1, Ad1)			\
 {{									\

--- a/src/pc/lua/smlua_functions_autogen.c
+++ b/src/pc/lua/smlua_functions_autogen.c
@@ -28427,6 +28427,55 @@ int smlua_func_gfx_parse(lua_State* L) {
     return 1;
 }
 
+int smlua_func_gfx_set_combine_lerp(lua_State* L) {
+    if (L == NULL) { return 0; }
+
+    int top = lua_gettop(L);
+    if (top != 17) {
+        LOG_LUA_LINE("Improper param count for '%s': Expected %u, Received %u", "gfx_set_combine_lerp", 17, top);
+        return 0;
+    }
+
+    Gfx* gfx = (Gfx*)smlua_to_cobject(L, 1, LOT_GFX);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 1, "gfx_set_combine_lerp"); return 0; }
+    u32 a0 = smlua_to_integer(L, 2);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 2, "gfx_set_combine_lerp"); return 0; }
+    u32 b0 = smlua_to_integer(L, 3);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 3, "gfx_set_combine_lerp"); return 0; }
+    u32 c0 = smlua_to_integer(L, 4);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 4, "gfx_set_combine_lerp"); return 0; }
+    u32 d0 = smlua_to_integer(L, 5);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 5, "gfx_set_combine_lerp"); return 0; }
+    u32 Aa0 = smlua_to_integer(L, 6);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 6, "gfx_set_combine_lerp"); return 0; }
+    u32 Ab0 = smlua_to_integer(L, 7);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 7, "gfx_set_combine_lerp"); return 0; }
+    u32 Ac0 = smlua_to_integer(L, 8);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 8, "gfx_set_combine_lerp"); return 0; }
+    u32 Ad0 = smlua_to_integer(L, 9);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 9, "gfx_set_combine_lerp"); return 0; }
+    u32 a1 = smlua_to_integer(L, 10);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 10, "gfx_set_combine_lerp"); return 0; }
+    u32 b1 = smlua_to_integer(L, 11);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 11, "gfx_set_combine_lerp"); return 0; }
+    u32 c1 = smlua_to_integer(L, 12);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 12, "gfx_set_combine_lerp"); return 0; }
+    u32 d1 = smlua_to_integer(L, 13);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 13, "gfx_set_combine_lerp"); return 0; }
+    u32 Aa1 = smlua_to_integer(L, 14);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 14, "gfx_set_combine_lerp"); return 0; }
+    u32 Ab1 = smlua_to_integer(L, 15);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 15, "gfx_set_combine_lerp"); return 0; }
+    u32 Ac1 = smlua_to_integer(L, 16);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 16, "gfx_set_combine_lerp"); return 0; }
+    u32 Ad1 = smlua_to_integer(L, 17);
+    if (!gSmLuaConvertSuccess) { LOG_LUA("Failed to convert parameter %u for function '%s'", 17, "gfx_set_combine_lerp"); return 0; }
+
+    gfx_set_combine_lerp(gfx, a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0, a1, b1, c1, d1, Aa1, Ab1, Ac1, Ad1);
+
+    return 1;
+}
+
 int smlua_func_gfx_set_cycle_type(lua_State* L) {
     if (L == NULL) { return 0; }
 
@@ -33831,6 +33880,7 @@ void smlua_bind_functions_autogen(void) {
     smlua_bind_function(L, "gfx_copy_lights_player_part", smlua_func_gfx_copy_lights_player_part);
     smlua_bind_function(L, "gfx_get_vtx", smlua_func_gfx_get_vtx);
     smlua_bind_function(L, "gfx_parse", smlua_func_gfx_parse);
+    smlua_bind_function(L, "gfx_set_combine_lerp", smlua_func_gfx_set_combine_lerp);
     smlua_bind_function(L, "gfx_set_cycle_type", smlua_func_gfx_set_cycle_type);
     smlua_bind_function(L, "gfx_set_env_color", smlua_func_gfx_set_env_color);
     smlua_bind_function(L, "gfx_set_fog_color", smlua_func_gfx_set_fog_color);

--- a/src/pc/lua/utils/smlua_gfx_utils.c
+++ b/src/pc/lua/utils/smlua_gfx_utils.c
@@ -214,3 +214,8 @@ void gfx_copy_lights_player_part(Gfx* gfx, u8 part) {
     if (!gfx) { return; }
     gSPCopyLightsPlayerPart(gfx, part);
 }
+
+void gfx_set_combine_lerp(Gfx* gfx, u32 a0, u32 b0, u32 c0, u32 d0, u32 Aa0, u32 Ab0, u32 Ac0, u32 Ad0, u32 a1, u32 b1, u32 c1, u32 d1,	u32 Aa1, u32 Ab1, u32 Ac1, u32 Ad1) {
+    if (!gfx) { return; }
+    gDPSetCombineLERPNoString(gfx, a0, b0, c0, d0, Aa0, Ab0, Ac0, Ad0, a1, b1, c1, d1, Aa1, Ab1, Ac1, Ad1);
+}

--- a/src/pc/lua/utils/smlua_gfx_utils.h
+++ b/src/pc/lua/utils/smlua_gfx_utils.h
@@ -58,5 +58,6 @@ void gfx_set_prim_color(Gfx* gfx, u8 m, u8 l, u8 r, u8 g, u8 b, u8 a);
 void gfx_set_env_color(Gfx* gfx, u8 r, u8 g, u8 b, u8 a);
 void gfx_set_fog_color(Gfx* gfx, u8 r, u8 g, u8 b, u8 a);
 void gfx_copy_lights_player_part(Gfx* gfx, u8 part);
+void gfx_set_combine_lerp(Gfx* gfx, u32 a0, u32 b0, u32 c0, u32 d0, u32 Aa0, u32 Ab0, u32 Ac0, u32 Ad0, u32 a1, u32 b1, u32 c1, u32 d1,	u32 Aa1, u32 Ab1, u32 Ac1, u32 Ad1);
 
 #endif


### PR DESCRIPTION
Adds gfx_set_combine_lerp to lua, which is equal to gDPSetCombineLERP from gbi.

You can use G_CCMUX and G_ACMUX constants to use it, example:
```lua
function geo_mod_cc(node, matStackIndex)
    local gfx = cast_graph_node(node.next).displayList
    if geo_get_mario_state().action == ACT_JUMP then
        gfx_set_combine_lerp(gfx,
            G_CCMUX_TEXEL0, G_CCMUX_0, G_CCMUX_SHADE, G_CCMUX_0,
            G_ACMUX_ENVIRONMENT, G_ACMUX_0, G_ACMUX_SHADE, G_ACMUX_0,
            G_CCMUX_TEXEL0, G_CCMUX_0, G_CCMUX_SHADE, G_CCMUX_0,
            G_ACMUX_ENVIRONMENT, G_ACMUX_0, G_ACMUX_SHADE, G_ACMUX_0)
    end
end
```